### PR TITLE
Make authtfaga work with PHP short_open_tag config option is set off

### DIFF
--- a/templates/login.php
+++ b/templates/login.php
@@ -4,17 +4,17 @@ $this->includeAtTemplateBase('includes/header.php');
 $this->data['header'] = $this->t('{authtfaga:login:authentication}');
 ?>
 
-<? if ($this->data['errorcode'] !== NULL) :?>
+<?php if ($this->data['errorcode'] !== NULL) :?>
 	<div style="border-left: 1px solid #e8e8e8; border-bottom: 1px solid #e8e8e8; background: #f5f5f5">
 		<img src="/<?php echo $this->data['baseurlpath']; ?>resources/icons/experience/gtk-dialog-error.48x48.png" style="float: left; margin: 15px " />
 		<h2><?php echo $this->t('{login:error_header}'); ?></h2>
 		<p><b><?php echo $this->t('{authtfaga:errors:title_' . $this->data['errorcode'] . '}'); ?></b></p>
 		<p><?php echo $this->t('{authtfaga:errors:descr_' . $this->data['errorcode'] . '}'); ?></p>
 	</div>
-<? endif; ?>
+<?php endif; ?>
 
 <form action="?" method="post" name="f" id="form">
-<? if ( $this->data['todo'] == 'choose2enable' ) : ?>
+<?php if ( $this->data['todo'] == 'choose2enable' ) : ?>
 	<h2><?php echo $this->t('{authtfaga:login:2factor_title}')?></h2>
 	<div class="loginbox">
 		<p class="logintitle"><?php echo $this->t('{authtfaga:login:chooseOTP}')?></p>
@@ -25,7 +25,7 @@ $this->data['header'] = $this->t('{authtfaga:login:authentication}');
         </p>
 	</div>
 
-<? elseif ( $this->data['todo'] == 'generateGA' ) : ?>
+<?php elseif ( $this->data['todo'] == 'generateGA' ) : ?>
 	<h2><?php echo $this->t('{authtfaga:login:2factor_title}')?></h2>
 	<div class="loginbox">	
 		<p class="logintitle"><?php echo $this->t('{authtfaga:login:qrcode}')?></p>
@@ -34,7 +34,7 @@ $this->data['header'] = $this->t('{authtfaga:login:authentication}');
         <p><input id="submit" class="submitbutton" type="submit" tabindex="2" name="submit" value="<?php echo $this->t('{authtfaga:login:next}')?>"/></p>
 	</div>
 
-<? elseif ( $this->data['todo'] == 'loginOTP' ) : ?>
+<?php elseif ( $this->data['todo'] == 'loginOTP' ) : ?>
 	<h2><?php echo $this->t('{authtfaga:login:2factor_login}')?></h2>
 	<div class="loginbox">
 		<p class="logintitle">
@@ -44,7 +44,7 @@ $this->data['header'] = $this->t('{authtfaga:login:authentication}');
 		</p>
 	</div>
 
-<? endif ; ?>
+<?php endif ; ?>
 
 <?php
 foreach ($this->data['stateparams'] as $name => $value) {


### PR DESCRIPTION
At the moment there are a few instances of PHP short open tags, which means that authtfaga doesn't work if the PHP short_open_tag ini directive is set to off (as it is by default in many new installs).
