### PR TITLE
Genericise

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
            'db.username' => 'simplesaml',
            'db.password' => 'bigsecret',
            'mainAuthSource' => 'ldap',
-           'uidField' => 'uid'
+           'uidField' => 'uid',
+           'totpIssuer' => dev_aai_teszt_IdP'
          ),
 ```

--- a/dictionaries/login.translation.json
+++ b/dictionaries/login.translation.json
@@ -27,7 +27,7 @@
 		"hu": "Add meg az aktuális ellenőrző kódot"
 	},
 	"2factor_login": {
-		"en": "Bejelentkezés ellenőrző kóddal"
+		"hu": "Bejelentkezés ellenőrző kóddal"
 	}
 
 }

--- a/lib/Auth/Source/authtfaga.php
+++ b/lib/Auth/Source/authtfaga.php
@@ -249,9 +249,9 @@ class sspmod_authtfaga_Auth_Source_authtfaga extends SimpleSAML_Auth_Source
      *
      * @return string
      */
-    public function getQRCodeGoogleUrl($name, $secret)
+    public function getQRCodeGoogleUrl($name, $issuer, $secret)
     {
-        $urlencoded = urlencode('otpauth://totp/'.$name.'?secret='.$secret.'');
+        $urlencoded = urlencode('otpauth://totp/'.$name.'?secret='.$secret.'&issuer='.$issuer);
 
         return 'https://chart.googleapis.com/chart?chs=200x200&chld=M|0&cht=qr&chl='.$urlencoded.'';
     }

--- a/www/login.php
+++ b/www/login.php
@@ -45,7 +45,8 @@ if (is_null($isEnabled) || isset($_GET['postSetEnable2fa'])) {
             $gaLogin->enable2fa($uid);
             $t->data['todo'] = 'generateGA';
             $t->data['autofocus'] = 'otp';
-            $t->data['qrcode'] = $gaLogin->getQRCodeGoogleUrl($uid.'-dev_aai_teszt_IdP', $gaKey);
+            $totpIssuer = empty($as['totpIssuer']) ? 'dev_aai_teszt_IdP' : $as['totpIssuer'];
+            $t->data['qrcode'] = $gaLogin->getQRCodeGoogleUrl($totpIssuer.':'.$uid, $totpIssuer, $gaKey);
         } elseif ($_POST['setEnable2f'] == 0) {
             $gaLogin->disable2fa($uid);
             SimpleSAML_Auth_Source::completeAuth($state);


### PR DESCRIPTION
Some minor changes to make this a bit more generic. Most importantly, allow the issuer to be configured so the IdP admin has control over what appears in Google Authenticator. I've tried to make it default - as close as possible - to the old behaviour.

Also a bugfix to the translations, so that login:2factor_login defaults to English rather than Hungarian.
