### PR TITLE
Fix a tiny typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,6 @@
            'db.password' => 'bigsecret',
            'mainAuthSource' => 'ldap',
            'uidField' => 'uid',
-           'totpIssuer' => dev_aai_teszt_IdP'
+           'totpIssuer' => 'dev_aai_teszt_IdP'
          ),
 ```


### PR DESCRIPTION
There was a missing quote in the example configuration.
