### PR TITLE
Don't use hardcoded authentication source ID

### DIFF
--- a/templates/login.php
+++ b/templates/login.php
@@ -29,7 +29,7 @@ $this->data['header'] = $this->t('{authtfaga:login:authentication}');
 	<h2><?php echo $this->t('{authtfaga:login:2factor_title}')?></h2>
 	<div class="loginbox">	
 		<p class="logintitle"><?php echo $this->t('{authtfaga:login:qrcode}')?></p>
-		<p><img src="<?=$this->data['qrcode'];?>" /></p>
+		<p><img src="<?php echo $this->data['qrcode'];?>" /></p>
         <p><input id="otp" class="yubifield" type="text" tabindex="1" name="otp" /></p>
         <p><input id="submit" class="submitbutton" type="submit" tabindex="2" name="submit" value="<?php echo $this->t('{authtfaga:login:next}')?>"/></p>
 	</div>

--- a/www/login.php
+++ b/www/login.php
@@ -4,7 +4,6 @@
  * @author Tamas Frank, NIIFI
  *
  */
-$as = SimpleSAML_Configuration::getConfig('authsources.php')->getValue('authtfaga');
 
 // Get session object
 $session = SimpleSAML_Session::getSession();
@@ -12,9 +11,16 @@ $session = SimpleSAML_Session::getSession();
 // Get the authetication state
 $authStateId = $_REQUEST['AuthState'];
 $state = SimpleSAML_Auth_State::loadState($authStateId, 'authtfaga.stage');
+assert('array_key_exists("SimpleSAML_Auth_Source.id", $state)');
+
+$authId = $state['SimpleSAML_Auth_Source.id'];
+$as = SimpleSAML_Configuration::getConfig('authsources.php')->getValue($authId);
 
 // Use 2 factor authentication class
-$gaLogin = SimpleSAML_Auth_Source::getById('authtfaga');
+$gaLogin = SimpleSAML_Auth_Source::getById($authId, 'sspmod_authtfaga_Auth_Source_authtfaga');
+if ($gaLogin === null) {
+    throw new Exception('Invalid authentication source: ' . $authId);
+}
 
 // Init template
 $template = 'authtfaga:login.php';


### PR DESCRIPTION
If 2FA has to be used with different mainAuthSource values, then
we must be able to use multiple definitions of the source, rather
than just assuming 'authtfaga'. This change looks up the current
state source and uses that as the source ID.
